### PR TITLE
Added mapping mattermost roles to the identity provider's groups

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -4,17 +4,17 @@
 /* eslint-disable max-lines */
 
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import {AccountMultipleOutlineIcon, ChartBarIcon, CogOutlineIcon, CreditCardOutlineIcon, FlaskOutlineIcon, FormatListBulletedIcon, InformationOutlineIcon, PowerPlugOutlineIcon, ServerVariantIcon, ShieldOutlineIcon, SitemapIcon, ProductsIcon} from '@mattermost/compass-icons/components';
+import { AccountMultipleOutlineIcon, ChartBarIcon, CogOutlineIcon, CreditCardOutlineIcon, FlaskOutlineIcon, FormatListBulletedIcon, InformationOutlineIcon, PowerPlugOutlineIcon, ServerVariantIcon, ShieldOutlineIcon, SitemapIcon, ProductsIcon } from '@mattermost/compass-icons/components';
 
-import {RESOURCE_KEYS} from 'mattermost-redux/constants/permissions_sysconsole';
+import { RESOURCE_KEYS } from 'mattermost-redux/constants/permissions_sysconsole';
 
-import {Constants, CloudProducts, LicenseSkus} from 'utils/constants';
-import {isCloudFreePlan} from 'utils/cloud_utils';
-import {isCloudLicense} from 'utils/license_utils';
-import {getSiteURL} from 'utils/url';
-import {t} from 'utils/i18n';
+import { Constants, CloudProducts, LicenseSkus } from 'utils/constants';
+import { isCloudFreePlan } from 'utils/cloud_utils';
+import { isCloudLicense } from 'utils/license_utils';
+import { getSiteURL } from 'utils/url';
+import { t } from 'utils/i18n';
 import {
     ldapTest, invalidateAllCaches, reloadConfig, testS3Connection,
     removeIdpSamlCertificate, uploadIdpSamlCertificate,
@@ -30,7 +30,7 @@ import PluginManagement from 'components/admin_console/plugin_management';
 import CustomPluginSettings from 'components/admin_console/custom_plugin_settings';
 import RestrictedIndicator from 'components/widgets/menu/menu_items/restricted_indicator';
 
-import {trackEvent} from 'actions/telemetry_actions.jsx';
+import { trackEvent } from 'actions/telemetry_actions.jsx';
 
 import ExternalLink from 'components/external_link';
 
@@ -470,7 +470,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.teamStatistics'),
             title_default: 'Team Statistics',
             searchableStrings: [
-                ['analytics.team.title', {team: ''}],
+                ['analytics.team.title', { team: '' }],
                 'analytics.system.info',
                 'analytics.team.totalPosts',
                 'analytics.team.activeUsers',
@@ -522,7 +522,7 @@ const AdminDefinition = {
             title: t('admin.sidebar.users'),
             title_default: 'Users',
             searchableStrings: [
-                ['admin.system_users.title', {siteName: ''}],
+                ['admin.system_users.title', { siteName: '' }],
             ],
             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.USERS)),
             isHidden: it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.USERS)),
@@ -1005,7 +1005,7 @@ const AdminDefinition = {
             title_default: 'Database',
             searchableStrings: [
                 'admin.database.title',
-                ['admin.recycle.recycleDescription', {featureName: '', reloadConfiguration: ''}],
+                ['admin.recycle.recycleDescription', { featureName: '', reloadConfiguration: '' }],
                 'admin.recycle.recycleDescription.featureName',
                 'admin.recycle.recycleDescription.reloadConfiguration',
                 'admin.recycle.button',
@@ -1051,10 +1051,10 @@ const AdminDefinition = {
             searchableStrings: [
                 'admin.elasticsearch.title',
                 'admin.elasticsearch.enableIndexingTitle',
-                ['admin.elasticsearch.enableIndexingDescription', {documentationLink: ''}],
+                ['admin.elasticsearch.enableIndexingDescription', { documentationLink: '' }],
                 'admin.elasticsearch.enableIndexingDescription.documentationLinkText',
                 'admin.elasticsearch.connectionUrlTitle',
-                ['admin.elasticsearch.connectionUrlDescription', {documentationLink: ''}],
+                ['admin.elasticsearch.connectionUrlDescription', { documentationLink: '' }],
                 'admin.elasticsearch.connectionUrlExample.documentationLinkText',
                 'admin.elasticsearch.skipTLSVerificationTitle',
                 'admin.elasticsearch.skipTLSVerificationDescription',
@@ -3232,8 +3232,8 @@ const AdminDefinition = {
             searchableStrings: [
                 'user.settings.security.passwordMinLength',
                 'admin.security.password',
-                ['admin.password.minimumLength', {max: '', min: ''}],
-                ['admin.password.minimumLengthDescription', {max: '', min: ''}],
+                ['admin.password.minimumLength', { max: '', min: '' }],
+                ['admin.password.minimumLengthDescription', { max: '', min: '' }],
                 'passwordRequirements',
                 'admin.password.lowercase',
                 'admin.password.uppercase',
@@ -3571,7 +3571,7 @@ const AdminDefinition = {
                                 help_text: t('admin.ldap.groupFilterFilterDesc'),
                                 help_text_markdown: true,
                                 help_text_default: '(Optional) Enter an AD/LDAP filter to use when searching for group objects. Only the groups selected by the query will be available to Mattermost. From [User Management > Groups]({siteURL}/admin_console/user_management/groups), select which AD/LDAP groups should be linked and configured.',
-                                help_text_values: {siteURL: getSiteURL()},
+                                help_text_values: { siteURL: getSiteURL() },
                                 placeholder: t('admin.ldap.groupFilterEx'),
                                 placeholder_default: 'E.g.: "(objectClass=group)"',
                                 isHidden: it.not(it.licensedForFeature('LDAPGroups')),
@@ -4021,59 +4021,59 @@ const AdminDefinition = {
                                             />
                                             <ul>
                                                 {updateCount > 0 &&
-                                                <li>
-                                                    <FormattedMessage
-                                                        id='admin.ldap.jobExtraInfo.updatedUsers'
-                                                        defaultMessage='Updated {updateCount, number} users.'
-                                                        values={{
-                                                            updateCount,
-                                                        }}
-                                                    />
-                                                </li>
+                                                    <li>
+                                                        <FormattedMessage
+                                                            id='admin.ldap.jobExtraInfo.updatedUsers'
+                                                            defaultMessage='Updated {updateCount, number} users.'
+                                                            values={{
+                                                                updateCount,
+                                                            }}
+                                                        />
+                                                    </li>
                                                 }
                                                 {deleteCount > 0 &&
-                                                <li>
-                                                    <FormattedMessage
-                                                        id='admin.ldap.jobExtraInfo.deactivatedUsers'
-                                                        defaultMessage='Deactivated {deleteCount, number} users.'
-                                                        values={{
-                                                            deleteCount,
-                                                        }}
-                                                    />
-                                                </li>
+                                                    <li>
+                                                        <FormattedMessage
+                                                            id='admin.ldap.jobExtraInfo.deactivatedUsers'
+                                                            defaultMessage='Deactivated {deleteCount, number} users.'
+                                                            values={{
+                                                                deleteCount,
+                                                            }}
+                                                        />
+                                                    </li>
                                                 }
                                                 {groupDeleteCount > 0 &&
-                                                <li>
-                                                    <FormattedMessage
-                                                        id='admin.ldap.jobExtraInfo.deletedGroups'
-                                                        defaultMessage='Deleted {groupDeleteCount, number} groups.'
-                                                        values={{
-                                                            groupDeleteCount,
-                                                        }}
-                                                    />
-                                                </li>
+                                                    <li>
+                                                        <FormattedMessage
+                                                            id='admin.ldap.jobExtraInfo.deletedGroups'
+                                                            defaultMessage='Deleted {groupDeleteCount, number} groups.'
+                                                            values={{
+                                                                groupDeleteCount,
+                                                            }}
+                                                        />
+                                                    </li>
                                                 }
                                                 {groupMemberDeleteCount > 0 &&
-                                                <li>
-                                                    <FormattedMessage
-                                                        id='admin.ldap.jobExtraInfo.deletedGroupMembers'
-                                                        defaultMessage='Deleted {groupMemberDeleteCount, number} group members.'
-                                                        values={{
-                                                            groupMemberDeleteCount,
-                                                        }}
-                                                    />
-                                                </li>
+                                                    <li>
+                                                        <FormattedMessage
+                                                            id='admin.ldap.jobExtraInfo.deletedGroupMembers'
+                                                            defaultMessage='Deleted {groupMemberDeleteCount, number} group members.'
+                                                            values={{
+                                                                groupMemberDeleteCount,
+                                                            }}
+                                                        />
+                                                    </li>
                                                 }
                                                 {groupMemberAddCount > 0 &&
-                                                <li>
-                                                    <FormattedMessage
-                                                        id='admin.ldap.jobExtraInfo.addedGroupMembers'
-                                                        defaultMessage='Added {groupMemberAddCount, number} group members.'
-                                                        values={{
-                                                            groupMemberAddCount,
-                                                        }}
-                                                    />
-                                                </li>
+                                                    <li>
+                                                        <FormattedMessage
+                                                            id='admin.ldap.jobExtraInfo.addedGroupMembers'
+                                                            defaultMessage='Added {groupMemberAddCount, number} group members.'
+                                                            values={{
+                                                                groupMemberAddCount,
+                                                            }}
+                                                        />
+                                                    </li>
                                                 }
                                             </ul>
                                         </span>
@@ -4691,7 +4691,7 @@ const AdminDefinition = {
                     return newState;
                 },
                 onConfigSave: (config) => {
-                    const newConfig = {...config};
+                    const newConfig = { ...config };
                     newConfig.GitLabSettings.UserAPIEndpoint = config.GitLabSettings.Url.replace(/\/$/, '') + '/api/v4/user';
                     return newConfig;
                 },
@@ -4826,7 +4826,7 @@ const AdminDefinition = {
                     return newState;
                 },
                 onConfigSave: (config) => {
-                    const newConfig = {...config};
+                    const newConfig = { ...config };
                     newConfig.GitLabSettings = config.GitLabSettings || {};
                     newConfig.Office365Settings = config.Office365Settings || {};
                     newConfig.GoogleSettings = config.GoogleSettings || {};
@@ -5194,7 +5194,7 @@ const AdminDefinition = {
                     return newState;
                 },
                 onConfigSave: (config) => {
-                    const newConfig = {...config};
+                    const newConfig = { ...config };
                     newConfig.Office365Settings = config.Office365Settings || {};
                     newConfig.GoogleSettings = config.GoogleSettings || {};
                     newConfig.GitLabSettings = config.GitLabSettings || {};
@@ -5538,6 +5538,30 @@ const AdminDefinition = {
                         help_text_default: 'Obtaining the Client Secret differs across providers. Please check you provider\'s documentation',
                         placeholder: t('admin.openid.clientSecretExample'),
                         placeholder_default: 'E.g.: "H8sz0Az-dDs2p15-7QzD231"',
+                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter),
+                        isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
+                    },
+                    {
+                        type: Constants.SettingsTypes.TYPE_TEXT,
+                        key: 'OpenIdSettings.SystemAdminGroup',
+                        label: t('admin.openid.systemAdminGroup'),
+                        label_default: 'System Admin Group mapping:',
+                        help_text: t('admin.openid.systemAdminGroupDescription'),
+                        help_text_default: 'Mapping the system_admin role to the group provided by the identity provider.',
+                        placeholder: t('admin.openid.systemAdminGroupExample'),
+                        placeholder_default: 'E.g.: "/mattermost-system-admin"',
+                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter),
+                        isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
+                    },
+                    {
+                        type: Constants.SettingsTypes.TYPE_TEXT,
+                        key: 'OpenIdSettings.SystemUserGroup',
+                        label: t('admin.openid.systemUserGroup'),
+                        label_default: 'System User Group mapping:',
+                        help_text: t('admin.openid.systemUserGroupDescription'),
+                        help_text_default: 'Mapping the system_user role to the group provided by the identity provider.',
+                        placeholder: t('admin.openid.systemUserGroupExample'),
+                        placeholder_default: 'E.g.: "/mattermost-system-user"',
                         isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter),
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
                     },
@@ -5967,7 +5991,7 @@ const AdminDefinition = {
                         help_text: t('admin.service.disableBotWhenOwnerIsDeactivated'),
                         help_text_default: 'When a user is deactivated, disables all bot accounts managed by the user. To re-enable bot accounts, go to [Integrations > Bot Accounts]({siteURL}/_redirect/integrations/bots).',
                         help_text_markdown: true,
-                        help_text_values: {siteURL: getSiteURL()},
+                        help_text_values: { siteURL: getSiteURL() },
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.INTEGRATIONS.BOT_ACCOUNTS)),
                     },
                 ],
@@ -6193,7 +6217,7 @@ const AdminDefinition = {
                 'admin.complianceExport.exportJobStartTime.title',
                 'admin.complianceExport.exportJobStartTime.description',
                 'admin.complianceExport.exportFormat.title',
-                ['admin.complianceExport.exportFormat.description', {siteURL: ''}],
+                ['admin.complianceExport.exportFormat.description', { siteURL: '' }],
                 'admin.complianceExport.createJob.title',
                 'admin.complianceExport.createJob.help',
                 'admin.complianceExport.globalRelayCustomerType.title',
@@ -6265,7 +6289,7 @@ const AdminDefinition = {
                         label: t('admin.compliance.newComplianceExportBanner'),
                         label_markdown: true,
                         label_default: 'This feature is replaced by a new [Compliance Export]({siteURL}/admin_console/compliance/export) feature, and will be removed in a future release. We recommend migrating to the new system.',
-                        label_values: {siteURL: getSiteURL()},
+                        label_values: { siteURL: getSiteURL() },
                         banner_type: 'info',
                         isHidden: it.not(it.licensedForFeature('Compliance')),
                     },
@@ -6919,7 +6943,7 @@ const AdminDefinition = {
             searchableStrings: [
                 'admin.bleve.title',
                 'admin.bleve.enableIndexingTitle',
-                ['admin.bleve.enableIndexingDescription', {documentationLink: ''}],
+                ['admin.bleve.enableIndexingDescription', { documentationLink: '' }],
                 'admin.bleve.enableIndexingDescription.documentationLinkText',
                 'admin.bleve.bulkIndexingTitle',
                 'admin.bleve.createJob.help',

--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -5542,6 +5542,16 @@ const AdminDefinition = {
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
                     },
                     {
+                        type: Constants.SettingsTypes.TYPE_BOOL,
+                        key: 'OpenIdSettings.EnableGroupsMapping',
+                        label: t('admin.openid.enableGroupsMapping'),
+                        label_default: 'Enable groups mapping:',
+                        help_text: t('admin.openid.systemAdminGroupDescription'),
+                        help_text_default: 'When true, enables mapping of mattermost system roles to groups provided by identity provider. ',
+                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter),
+                        isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
+                    },
+                    {
                         type: Constants.SettingsTypes.TYPE_TEXT,
                         key: 'OpenIdSettings.SystemAdminGroup',
                         label: t('admin.openid.systemAdminGroup'),
@@ -5550,7 +5560,7 @@ const AdminDefinition = {
                         help_text_default: 'Mapping the system_admin role to the group provided by the identity provider.',
                         placeholder: t('admin.openid.systemAdminGroupExample'),
                         placeholder_default: 'E.g.: "/mattermost-system-admin"',
-                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter),
+                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter, it.stateIsFalse('OpenIdSettings.EnableGroupsMapping')),
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
                     },
                     {
@@ -5562,7 +5572,7 @@ const AdminDefinition = {
                         help_text_default: 'Mapping the system_user role to the group provided by the identity provider.',
                         placeholder: t('admin.openid.systemUserGroupExample'),
                         placeholder_default: 'E.g.: "/mattermost-system-user"',
-                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter),
+                        isHidden: it.any(it.not(it.stateEquals('openidType', Constants.OPENID_SERVICE)), it.licensedForCloudStarter, it.stateIsFalse('OpenIdSettings.EnableGroupsMapping')),
                         isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.OPENID)),
                     },
                     {

--- a/e2e/playwright/support/server/default_config.ts
+++ b/e2e/playwright/support/server/default_config.ts
@@ -420,6 +420,8 @@ const defaultServerConfig: AdminConfig = {
         DiscoveryEndpoint: '',
         ButtonText: '',
         ButtonColor: '#145DBF',
+        SystemAdminGroup: '',
+        SystemUserGroup: '',
     },
     LdapSettings: {
         Enable: false,

--- a/e2e/playwright/support/server/default_config.ts
+++ b/e2e/playwright/support/server/default_config.ts
@@ -420,6 +420,7 @@ const defaultServerConfig: AdminConfig = {
         DiscoveryEndpoint: '',
         ButtonText: '',
         ButtonColor: '#145DBF',
+        EnableGroupsMapping: false,
         SystemAdminGroup: '',
         SystemUserGroup: '',
     },

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -582,6 +582,7 @@ export type SSOSettings = {
     DiscoveryEndpoint: string;
     ButtonText: string;
     ButtonColor: string;
+    EnableGroupsMapping: boolean;
     SystemAdminGroup: string;
     SystemUserGroup: string;
 };

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -251,7 +251,7 @@ export type RequestLicenseBody = {
     users: number;
     terms_accepted: boolean;
     receive_emails_accepted: boolean;
-}
+};
 
 export type DataRetentionPolicy = {
     message_deletion_enabled: boolean;
@@ -582,6 +582,8 @@ export type SSOSettings = {
     DiscoveryEndpoint: string;
     ButtonText: string;
     ButtonColor: string;
+    SystemAdminGroup: string;
+    SystemUserGroup: string;
 };
 
 export type Office365Settings = {
@@ -907,15 +909,15 @@ export type ReplicaLagSetting = {
     DataSource: string;
     QueryAbsoluteLag: string;
     QueryTimeLag: string;
-}
+};
 
 export type EnvironmentConfigSettings<T> = {
     [P in keyof T]: boolean;
-}
+};
 
 export type EnvironmentConfig = {
     [P in keyof AdminConfig]: EnvironmentConfigSettings<AdminConfig[P]>;
-}
+};
 
 export type WarnMetricStatus = {
     id: string;
@@ -925,8 +927,8 @@ export type WarnMetricStatus = {
 };
 
 export enum CollapsedThreads {
-    DISABLED = 'disabled',
-    DEFAULT_ON = 'default_on',
-    DEFAULT_OFF = 'default_off',
-    ALWAYS_ON = 'always_on',
+    DISABLED = "disabled",
+    DEFAULT_ON = "default_on",
+    DEFAULT_OFF = "default_off",
+    ALWAYS_ON = "always_on",
 }


### PR DESCRIPTION
### Added the ability to make your custom groups provided by Identity Provider correspond to the "mattermost" system groups.

Groups must be contained in the "groups:" field of the ID token.
![Снимок экрана 2023-06-02 в 16 55 20](https://github.com/qiwi-forks/mattermost-webapp/assets/63290844/4b0f8700-efdd-4232-9617-54ac7a92990b)

![Снимок экрана 2023-06-02 в 16 56 26](https://github.com/qiwi-forks/mattermost-webapp/assets/63290844/61115292-86cf-4685-9197-d719e6353a1d)
